### PR TITLE
Fixed documentation for 'encodeSubmitValue' parameter.

### DIFF
--- a/src/BoxSelect.js
+++ b/src/BoxSelect.js
@@ -86,8 +86,8 @@ Ext.define('Ext.ux.form.field.BoxSelect', {
      * @cfg {Boolean} encodeSubmitValue
      * Controls the formatting of the form submit value of the field. (defaults to <code>false</code>). This
      * is not applicable of {@link #multiSelect} is false.
-     * <code>true</code> for the field value to submit as a json encoded array in a single POST variable
-     * <code>false</code> for the field to submit as an array of POST variables
+     * <code>true</code> for the field value to submit as a json encoded array in a single GET/POST variable
+     * <code>false</code> for the field to submit as an array of GET/POST variables
      */
     encodeSubmitValue: false,
 


### PR DESCRIPTION
Hi there,

I love your BoxSelect class! It's very great!

I've fixed a minor error within the documentation of the 'encodeSubmitValue' parameter. The selected combobox fields are not only submitted if the form uses a POST request, but also submitted if the form uses a GET request.

I'd be happy if you can pull this into your repo.

Thank you again for this awesome class!
- Konrad
