### PR TITLE
Error in console when box selects are in a collapsed panel on page load.

### DIFF
--- a/src/BoxSelect.js
+++ b/src/BoxSelect.js
@@ -471,8 +471,11 @@ Ext.define('Ext.ux.form.field.BoxSelect', {
     alignPicker: function() {
         var me = this,
         picker, isAbove,
-        aboveSfx = '-above',
-        itemBox = me.itemList.getBox(false, true);
+        aboveSfx = '-above';
+        
+        if(me.itemList) {
+            var itemBox = me.itemList.getBox(false, true);
+        }     
 
         if (this.isExpanded) {
             picker = me.getPicker();


### PR DESCRIPTION
using the current version of boxSelect.js and ExtJS 4.0.6 I get the following error when box selects are in a panel that is collapsed during page load. 

Uncaught TypeError: Cannot call method 'getBox' of undefined

adding 

``` javascript
if(me.itemList)
```

before calling 

``` javascript
me.itemList.getBox() 
```

resolved the error for me
