### PR TITLE
Fix valueStore/SelectionModel destruction order.

### DIFF
--- a/src/BoxSelect.js
+++ b/src/BoxSelect.js
@@ -406,7 +406,7 @@ Ext.define('Ext.ux.form.field.BoxSelect', {
     onDestroy: function() {
         var me = this;
 
-        Ext.destroyMembers(me, 'selectionModel', 'valueStore');
+        Ext.destroyMembers(me, 'valueStore', 'selectionModel');
 
         me.callParent(arguments);
     },


### PR DESCRIPTION
This changes the order on which the valueStore and selectionModel objects are destroyed. Apparently when detroying the value store, the tpl is ran and it depends on the selectionModel for the isSelected implementation. When a view is being destroyed the boxselect would generate a "XTemplate Error: Cannot call method 'isSelected' of undefined" console log message for each element on the valueStore.
