### PR TITLE
Expand after async setValue shows only the current value(s)

### DIFF
--- a/src/BoxSelect.js
+++ b/src/BoxSelect.js
@@ -1290,6 +1290,7 @@ Ext.define('Ext.ux.form.field.BoxSelect', {
                     }
                     me.setValue(value, doSelect, true);
                     me.autoSize();
+                    me.lastQuery = false;
                 }
             });
             return false;


### PR DESCRIPTION
This change attempts to fix an issue where the picker list displays only the currently selected records after an async setValue call is performed.
## Steps to Reproduce
1. Set up a situation where we have a BoxSelect attached to a paged store and a way to programmatically call setValue, passing a value that does not appear in the first page of results. Something like this:
   
   ``` javascript
   Ext.define('MyStore', {
       extend: 'Ext.data.Store',
       idProperty: 'value',
       pageSize: 10,
       fields: [
           'value',
           'display'
       ],
       proxy: {
           type: 'ajax',
           url: 'data.cfm',
           reader: {
               type: 'json',
               root: 'results'
           }
       }
   });
   
   Ext.onReady(function() {
       var boxSelect = Ext.create('Ext.ux.form.field.BoxSelect', {
           renderTo: Ext.getBody(),
           width: 400,
           store: Ext.create('MyStore'),
           pageSize: 10,
           queryMode: 'remote',
           displayField: 'display',
           valueField: 'value'
       });
   
       Ext.create('Ext.button.Button', {
           text: 'call setValue(11)',
           renderTo: Ext.getBody(),
           handler: function() {
               boxSelect.setValue(11);
           }
       });
   });
   ```
2. Expand the list and allow the first page of results to load.
3. Collapse the list, trigger the setValue call, and allow the record to load in the field.
4. Expand the list again, only the current record(s) will appear.
