### PR TITLE
fixed call to createFilterFn in onTypeAhead

### DIFF
--- a/src/BoxSelect.js
+++ b/src/BoxSelect.js
@@ -991,9 +991,9 @@ Ext.define('Ext.ux.form.field.BoxSelect', {
         record, newValue, len, selStart;
 
         if (me.filterPickList) {
-            var fn = this.createFilterFn(displayField, inputElDom.value);
+            var fn = me.store.createFilterFn(displayField, inputElDom.value);
             record = me.store.findBy(function(rec) {
-                return ((valueStore.indexOfId(rec.getId()) === -1) && fn(rec));
+                return ((valueStore.indexOfId(rec.getId()) === -1) && (!fn ||fn(rec)));
             });
             record = (record === -1) ? false : me.store.getAt(record);
         } else {


### PR DESCRIPTION
This is strange, under 4.2 I encountered an error in onTypeAhead's attempt to call this.createFilterFn which was undefined.

I cannot in the history of ExtJS 4.x find a version where ComboBox has a createFilterFn method, judging by the parameters the intended method is Store.createFilterFn.

This error doesn't surface on the demo page because it runs 4.1.1, which oddly makes no use of an onTypeAhead method in ComboBox or its parents -- the override containing the error never gets called, making me wonder if it is even necessary? onTypeAhead exists in 4.1.3+ though

Store.createFilterFn returns false if the value string is blank, necessitating an extra check

I'm not sure if this onTypeAhead override is still needed, but this patch seems to fix it under versions of ExtJS that implement ComboBox.onTypeAhead
